### PR TITLE
Fix infinite loading when changing word length

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -46,11 +46,11 @@ function setLength() {
     words = big_list.filter((a) =>  a.length == word_length);
     // words = official_guesses.slice(); // uncomment to use original wordle guess list
     
+    setWordbank();
+    
     if (current != word_length) {
         clearGrids();
     }
-
-    setWordbank();
 }
 
 function setWordbank() {


### PR DESCRIPTION
Since 52d930edce655e3b7728244d3250766337b5d42e changing the word length of the bot results in infinite loading (at least during my testing). Invoking setWordbank before clearGrids fixes this issue as the relevant data that is used in the newly added update function is present. This will also fix the intermittent issue where when refreshing while the update function is running the site will fail to load as the "common" variable is undefined.