### PR TITLE
Changed URL of general.js to account for ybenhayun being renamed to yuvalbht

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Note-- the first metric is only used to reduce the testing size to 50 (as suppos
 The largest thing I'm currently working on, other than minor polishes and bug fixes to the site, is increasing the efficiency of the bot without sacrificing overall average.
 
 # Site
-You can play around with the bot yourself [here](https://ybenhayun.github.io/wordlebot/)
+You can play around with the bot yourself [here](https://yuvalbht.github.io/wordlebot/)

--- a/index.html
+++ b/index.html
@@ -24,8 +24,7 @@
     <script type = "text/javascript" src = "js/class.js"></script>
     <script type = "text/javascript" src = "js/main.js"></script>
     <script type = "text/javascript" src = "js/bot.js"></script>
-    <script type = "text/javascript" src = "https://ybenhayun.github.io/general.js"></script>
-    <script type = "text/javascript" src = "../webpage/general.js"></script>
+    <script type = "text/javascript" src = "https://yuvalbht.github.io/general.js"></script>
 	<title>WordleBot</title>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
             Like the bot? <a href="https://ko-fi.com/ybenhayun"  target="_blank">Buy me a coffee!</a>
         </p>
         <p class="links github">
-            Do you code? Check out this repo on <a href="https://github.com/ybenhayun" target="_blank">Github</a>.
+            Do you code? Check out this repo on <a href="https://github.com/yuvalbht" target="_blank">Github</a>.
         </p>
     </div>
 


### PR DESCRIPTION
I believe the github account ybenhayun has been renamed to yuvalbht, and this broke the link to general.js

I also removed the `../webpage/general.js` link as that is a dead link, and I assume the same file.

I'd recommend pushing general.js into the js folder of this repo so anyone can host it locally, but that's not my prerogative. I figured this was the smallest possible change to get it working again.